### PR TITLE
Implement electric colon

### DIFF
--- a/python.el
+++ b/python.el
@@ -748,7 +748,8 @@ With numeric ARG, just insert that many colons. With
   (and (not arg)
        (not (nth 8 (syntax-ppss)))
        (eolp)
-       (save-excursion (back-to-indentation) (python-indent-line nil))))
+       (> (current-indentation) (python-indent-calculate-indentation))
+       (save-excursion (back-to-indentation) (python-indent-dedent-line))))
 (put 'python-electric-colon 'delete-selection t)
 
 (defun python-indent-shift-left (start end &optional count)


### PR DESCRIPTION
This is partially taken from the original python-mode.

This is a pull request for ticket #10 and makes the python mode to dedent when entering ":" in cases like "else:", "elif:" or "except:".
