### PR TITLE
Fix minor completion bug

### DIFF
--- a/python.el
+++ b/python.el
@@ -1633,8 +1633,9 @@ completions on the current context."
 		     (string-match "^\\(from\\|import\\)[ \t]" line))
 		(python-shell-completion--get-completions
 		 line process python-shell-module-completion-string-code)
-	      (python-shell-completion--get-completions
-	       input process python-shell-completion-string-code)))
+	      (and (> (length input) 0)
+		   (python-shell-completion--get-completions
+		    input process python-shell-completion-string-code))))
 	   (completion (when completions
 			 (try-completion input completions))))
       (cond ((eq completion t)


### PR DESCRIPTION
Hi Fabian,

The first of these commits fixes a bug: requesting completion with point after

foo()

there's a python exception (the result of calling get_ipython().Completer.all_completions('''''')) which is displayed in the completion buffer.

The second commit strips off a new line character from the returned python string. (I can imagine you may want to do this in a more lightweight fashion)

Dan
