### PR TITLE
Don't request completions for zero-length input

### DIFF
--- a/python.el
+++ b/python.el
@@ -1633,8 +1633,9 @@ completions on the current context."
 		     (string-match "^\\(from\\|import\\)[ \t]" line))
 		(python-shell-completion--get-completions
 		 line process python-shell-module-completion-string-code)
-	      (python-shell-completion--get-completions
-	       input process python-shell-completion-string-code)))
+	      (and (> (length input) 0)
+		   (python-shell-completion--get-completions
+		    input process python-shell-completion-string-code))))
 	   (completion (when completions
 			 (try-completion input completions))))
       (cond ((eq completion t)


### PR DESCRIPTION
Fixes a bug in which incorrect completion output was displayed, for
example when point was after a closing paren.
