### PR TITLE
Allowed a more sensible tab-width than 8 to be optionally set

### DIFF
--- a/python.el
+++ b/python.el
@@ -2586,7 +2586,8 @@ to \"^python-\"."
 \\{python-mode-map}
 Entry to this mode calls the value of `python-mode-hook'
 if that value is non-nil."
-  (set (make-local-variable 'tab-width) 8)
+  (set (make-local-variable 'tab-width)
+       (or (and (boundp 'python-tab-width) python-tab-width) 8))
   (set (make-local-variable 'indent-tabs-mode) nil)
 
   (set (make-local-variable 'comment-start) "# ")


### PR DESCRIPTION
Forcing a tab-width of 8 is a bit aggressive, so there's now an optional variable `python-tab-width` which if defined is used as the tab-width.
