### PR TITLE
Fixed setup example for iPython 0.10.

### DIFF
--- a/python.el
+++ b/python.el
@@ -84,11 +84,15 @@
 ;;  python-shell-completion-string-code
 ;;    "';'.join(get_ipython().Completer.all_completions('''%s'''))\n")
 
-;; For iPython 0.10 everything would be the same except for
-;; `python-shell-completion-string-code':
+;; For iPython 0.10, it would be:
 
-;; (setq python-shell-completion-string-code
-;;       "';'.join(__IP.complete('''%s'''))\n")
+;; (setq
+;;  python-shell-interpreter "ipython"
+;;  python-shell-interpreter-args ""
+;;  python-shell-prompt-regexp "In \\[[0-9]+\\]: "
+;;  python-shell-prompt-output-regexp "Out\\[[0-9]+\\]: "
+;;  python-shell-completion-string-code
+;;    "';'.join(__IP.complete('''%s'''))\n")
 
 ;; Unfortunately running iPython on Windows needs some more tweaking.
 ;; The way you must set `python-shell-interpreter' and


### PR DESCRIPTION
It looks like that IPython.core is introduced since 0.11 [1] [2].
Therefore, module_completion cannot be used in 0.10.

I also think it would be better if python.el provides some util function so that I can call that function instead of writing all these setq in my setup.

[1] https://github.com/ipython/ipython/tree/rel-0.10.2/IPython
[2] https://github.com/ipython/ipython/tree/rel-0.11/IPython
