### PR TITLE
Add python-shell-completion-func to customize python-shell-completion-complete-at-point

### DIFF
--- a/python.el
+++ b/python.el
@@ -207,7 +207,8 @@
   ;; Avoid compiler warnings
   (defvar view-return-to-alist)
   (defvar compilation-error-regexp-alist)
-  (defvar outline-heading-end-regexp))
+  (defvar outline-heading-end-regexp)
+  (defun auto-complete (&optional args)))
 
 (autoload 'comint-mode "comint")
 


### PR DESCRIPTION
Hi, I made the completion of `python-shell-completion-complete-at-point` configurable by adding `python-shell-completion-func` custom variable.

I also added two examples of `python-shell-completion-func`, using ido and auto-complete.  I don't know if these two better be in python.el, but I think making `python-shell-completion-complete-at-point` configurable is a good idea.
