### PR TITLE
Use `completion-at-point` instead of `comint-dynamic-complete`

### DIFF
--- a/python.el
+++ b/python.el
@@ -1791,7 +1791,7 @@ to complete."
                     (buffer-substring (comint-line-beginning-position)
                                       (point-marker)))
       (indent-for-tab-command)
-    (comint-dynamic-complete)))
+    (completion-at-point)))
 
 
 ;;; PDB Track integration


### PR DESCRIPTION
(This may be more a request for help/explanation than a pull request.)

I'm finding that completion only works for me if I change `comint-dynamic-complete` to `completion-at-point`. Perhaps I don't really understand the respective roles of these two functions.  The docs for `completion-at-point-functions` make it clear that the completer functions should return `(list beg end completions)` (as `python-shell-completion--do-completion-at-point` does). But the docs for `comint-dynamic-complete` suggest that the completer functions actually have to _do_ the completion themselves:

```
Dynamically perform completion at point.
Calls the functions in `comint-dynamic-complete-functions' to perform
completion until a function returns non-nil, at which point completion is
assumed to have occurred.
```

So with your simplification at a52913b13354efab0954cfee6e632e817e78e1a2, what code is actually handling the completion operations (display of alternatives, insertion of completion)?
