### PR TITLE
Deactivate mark on python-shell-send-region

### DIFF
--- a/python.el
+++ b/python.el
@@ -1591,8 +1591,7 @@ Returns the output.  See `python-shell-send-string-no-output'."
 (defun python-shell-send-region (start end)
   "Send the region delimited by START and END to inferior Python process."
   (interactive "r")
-  (let ((deactivate-mark nil))
-    (python-shell-send-string (buffer-substring start end) nil t)))
+  (python-shell-send-string (buffer-substring start end) nil t))
 
 (defun python-shell-send-buffer ()
   "Send the entire buffer to inferior Python process."


### PR DESCRIPTION
To use `python-shell-send-region`, the user
1. Selects a region. In modern emacs they will be using `transient-mark-mode` and the region will be visually highlighted
2. Issues `python-shell-send-region`

With the current code, at this point the region will have been sent to the python process, and it will still be highlighted in the code buffer.

With this change, highlighting is removed when the code is sent to the python process. I find the removal of the highlighting to be a nice visual confirmation that the code has been sent, and I like that I don't have to manually remove the highlighting.

However it looks like the

``` lisp
(let ((deactivate-mark nil))
...
```

line was put there deliberately, so perhaps I am overlooking a reason for this.
