### PR TITLE
Allow syntax highlighting in the python shell

### DIFF
--- a/python.el
+++ b/python.el
@@ -1219,7 +1219,7 @@ It should not contain a caret (^) at the beginning."
   :group 'python
   :safe 'stringp)
 
-(defcustom python-shell-enable-syntax-highlighting t
+(defcustom python-shell-enable-font-lock t
   "Should syntax highlighting be enabled in the python shell buffer?
 Restart the python shell after changing this variable for it to take effect."
   :type 'boolean
@@ -1385,7 +1385,7 @@ controls which Python interpreter is run.  Variables
 `python-shell-prompt-regexp',
 `python-shell-prompt-output-regexp',
 `python-shell-prompt-block-regexp',
-`python-shell-enable-syntax-highlighting',
+`python-shell-enable-font-lock',
 `python-shell-completion-setup-code',
 `python-shell-completion-string-code',
 `python-shell-completion-module-string-code',
@@ -1419,7 +1419,7 @@ variable.
                'python-shell-completion-complete-at-point)
   (define-key inferior-python-mode-map (kbd "<tab>")
     'python-shell-completion-complete-or-indent)
-  (when python-shell-enable-syntax-highlighting
+  (when python-shell-enable-font-lock
     (set
      (make-local-variable 'font-lock-defaults)
      '(python-font-lock-keywords


### PR DESCRIPTION
This does result in fontification of unquoted text as python code, which may bother some people.

But I'm enjoying having it on and the default is `on` in the commit.

The other comint mode that I have used extensively -- [ESS](https://github.com/emacsmirror/ess.git) -- does enable font lock in the inferior R buffer, although I think a subset of syntactical elements are highlighted in the inferior R buffer versus the code editing buffers.
