### PR TITLE
Do not move cursor in python-indent-line

### DIFF
--- a/python.el
+++ b/python.el
@@ -591,7 +591,7 @@ These make `python-indent-calculate-indentation' subtract the value of
                  (goto-char block-end)
                  (python-util-forward-comment)
                  (current-indentation))))
-          (if indentation
+          (if (and indentation (> indentation 0))
               (setq python-indent-offset indentation)
             (message "Can't guess python-indent-offset, using defaults: %s"
                      python-indent-offset)))))))


### PR DESCRIPTION
After indenting a line, cursor was moved to the beginning of the
indent (at the first non-space character in the line).  This change
prevent this movement and make the relative position of the cursor
from the indent the same after indenting line.  This behavior is
consistent with other major mode such as emacs-lisp-mode.
