### PR TITLE
Fontify docstring with font-lock-doc-face

### DIFF
--- a/python.el
+++ b/python.el
@@ -413,15 +413,21 @@ The type returned can be `comment', `string' or `paren'."
   'python-info-ppss-comment-or-string-p
   #'python-syntax-comment-or-string-p "24.3")
 
+(defun python-docstring-at-p (pos)
+  "Check to see if there is a docstring at POS."
+  (save-excursion
+    (goto-char pos)
+    (if (looking-at-p "'''\\|\"\"\"")
+        (progn
+          (python-nav-backward-statement)
+          (looking-at "\\`\\|class \\|def "))
+      nil)))
+
 (defun python-font-lock-syntactic-face-function (state)
   (if (nth 3 state)
-      (let ((startpos (nth 8 state)))
-        (save-excursion
-          (goto-char startpos)
-          (if (and (looking-at-p "'''\\|\"\"\"")
-                   (looking-back "\\(?:\\`\\|^\\s *\\(?:class\\|def\\)\\s +.*\\)\n*\\(?:\\s *#\\s *.*\n\\)*\\s *"))
-              font-lock-doc-face
-            font-lock-string-face)))
+      (if (python-docstring-at-p (nth 8 state))
+          font-lock-doc-face
+        font-lock-string-face)
     font-lock-comment-face))
 
 (defvar python-font-lock-keywords

--- a/python.el
+++ b/python.el
@@ -413,6 +413,17 @@ The type returned can be `comment', `string' or `paren'."
   'python-info-ppss-comment-or-string-p
   #'python-syntax-comment-or-string-p "24.3")
 
+(defun python-font-lock-syntactic-face-function (state)
+  (if (nth 3 state)
+      (let ((startpos (nth 8 state)))
+        (save-excursion
+          (goto-char startpos)
+          (if (and (looking-at-p "'''\\|\"\"\"")
+                   (looking-back "\\`\\|^\\s *\\(?:class\\|def\\)\\s +\\(?:\\sw\\|\\s_\\)+(.*):\n\\s *"))
+              font-lock-doc-face
+            font-lock-string-face)))
+    font-lock-comment-face))
+
 (defvar python-font-lock-keywords
   ;; Keywords
   `(,(rx symbol-start
@@ -3278,7 +3289,10 @@ if that value is non-nil."
        'python-nav-forward-sexp)
 
   (set (make-local-variable 'font-lock-defaults)
-       '(python-font-lock-keywords nil nil nil nil))
+       '(python-font-lock-keywords
+         nil nil nil nil
+         (font-lock-syntactic-face-function
+          . python-font-lock-syntactic-face-function)))
 
   (set (make-local-variable 'syntax-propertize-function)
        python-syntax-propertize-function)

--- a/python.el
+++ b/python.el
@@ -419,7 +419,7 @@ The type returned can be `comment', `string' or `paren'."
         (save-excursion
           (goto-char startpos)
           (if (and (looking-at-p "'''\\|\"\"\"")
-                   (looking-back "\\`\\|^\\s *\\(?:class\\|def\\)\\s +\\(?:\\sw\\|\\s_\\)+(.*):\n\\s *"))
+                   (looking-back "\\(?:\\`\\|^\\s *\\(?:class\\|def\\)\\s +.*\\)\n*\\(?:\\s *#\\s *.*\n\\)*\\s *"))
               font-lock-doc-face
             font-lock-string-face)))
     font-lock-comment-face))


### PR DESCRIPTION
I thought it would be fun to use `font-lock-doc-string` to fontify docstrings,  just like in the, or most, lisp modes. Please let me know what you think.
